### PR TITLE
Fixed C and C# Links Issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@
 
  - [JavaScript](#javascript)
  - [Java](#java)
- - [C#](#c-1)
+ - [C#](#c)
  - [CSS](#css)
  - [HTML](#html)
- - [C](undefined)
+ - [C](#c-1)
  - [C++](#c-2)
  - [Go](#go)
  - [Haskell](#haskell)


### PR DESCRIPTION
Opened this PR to fix below issue :

Issue --> C and C# links in Contents section are not working

![links issue](https://user-images.githubusercontent.com/25107841/47332930-b2ef3c80-d69e-11e8-9550-1b439a7ef92f.gif)
